### PR TITLE
Fix beta coefficient in Eq.51

### DIFF
--- a/src/ussa1976/constants.py
+++ b/src/ussa1976/constants.py
@@ -103,7 +103,7 @@ T0 = 288.15
 S = 110.4
 """Sutherland constant in eq. 51 of :cite:`NASA1976USStandardAtmosphere` [K]."""
 
-BETA = 1.458e6
+BETA = 1.458e-6
 """:math:`\\beta` constant in eq. 51 of :cite:`NASA1976USStandardAtmosphere`
 [kg * m^-1 * s^-1 * K^-0.5]."""
 


### PR DESCRIPTION
In the US 1976 atmosphere publication, the coefficient beta is 1.458e-6, not 1.458e6. 

I think this may be an error in the code? (I haven't seen any correction to the original publication which reference this).